### PR TITLE
Allow Fields to be saved by an ACTION request.

### DIFF
--- a/third_party/taggable/ft.taggable.php
+++ b/third_party/taggable/ft.taggable.php
@@ -36,7 +36,7 @@ class Taggable_ft extends EE_Fieldtype
 	 */
 	public function __construct()
 	{
-		parent::EE_Fieldtype();
+		parent::__construct();
 		$this->EE->lang->loadfile('taggable');
 	}
 

--- a/third_party/taggable/ft.taggable.php
+++ b/third_party/taggable/ft.taggable.php
@@ -201,8 +201,8 @@ class Taggable_ft extends EE_Fieldtype
 			$this->settings = array_merge($this->settings, unserialize(base64_decode($this->settings['field_settings'])));
 		}
 		
-		// Are we on a CP request?
-		if (REQ == 'CP')
+		// Are we on a CP request or an ACTION request?
+		if (REQ == 'CP' || REQ == 'ACTION')
 		{
 			if ($data)
 			{


### PR DESCRIPTION
This allows the channel entries api to modify taggable formatted fields when called through action requests, (i.e. SOAP / XML-RPC / etc ...)  This is mentioned in Issue #8 
