### PR TITLE
Deprecated calls replaced + removal of old licence key refs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ And you've installed Taggable!
 Complete usage documentation is available in the repo. I want to convert it all over to Markdown and chuck in this repo's wiki.
 
 ## Changelog
+**Version 1.4.7**
+* Fixed residual references to $license_key bug
 
 **Version 1.4.6**
 * Fixing a styling conflict with Playa 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Complete usage documentation is available in the repo. I want to convert it all 
 
 ## Changelog
 **Version 1.4.7**
+* Replaced calls that were deprecated in EE version 2.6
+
+**Version 1.4.7**
 * Fixed residual references to $license_key bug
 
 **Version 1.4.6**

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ And you've installed Taggable!
 Complete usage documentation is available in the repo. I want to convert it all over to Markdown and chuck in this repo's wiki.
 
 ## Changelog
-**Version 1.4.7**
+**Version 1.4.8**
 * Replaced calls that were deprecated in EE version 2.6
 
 **Version 1.4.7**

--- a/third_party/taggable/ft.taggable.php
+++ b/third_party/taggable/ft.taggable.php
@@ -8,7 +8,8 @@
  * @author Jamie Rumbelow <http://jamierumbelow.net>
  * @copyright Copyright (c)2010 Jamie Rumbelow
  * @license http://getsparkplugs.com/taggable/docs#license
- * @version 1.4.6
+ * @version  1.4.8
+ * 
  **/
 
 require_once PATH_THIRD."taggable/libraries/Model.php";
@@ -33,10 +34,12 @@ class Taggable_ft extends EE_Fieldtype
 	
 	/**
 	 * Constructor
+	 * 
+	 * @since vsrion 1.4.8 Replaced deprecated call parent::EE_FiedldType()
 	 */
 	public function __construct()
 	{
-		parent::EE_Fieldtype();
+		EE_Fieldtype::__construct();
 		$this->EE->lang->loadfile('taggable');
 	}
 
@@ -712,6 +715,8 @@ class Taggable_ft extends EE_Fieldtype
 	
 	/**
 	 * Sets up JavaScript globals
+	 * 
+	 * @since version 1.4.8 Replaced deprecated call to generate_json()
 	 */
 	private function _setup_javascript()
 	{		
@@ -731,7 +736,7 @@ class Taggable_ft extends EE_Fieldtype
 			);
 			
 			// Set and output the JS
-			$json = $this->EE->javascript->generate_json($js);
+			$json = json_encode($js);
 			$output = '<script type="text/javascript">if (typeof EE == "undefined" || ! EE) {'."\n".'var EE = {"taggable": '.$json;
 			$output .= '};} else { EE.taggable = ' . $json . ' }</script>';
 			$this->EE->cp->add_to_foot($output);

--- a/third_party/taggable/mcp.taggable.php
+++ b/third_party/taggable/mcp.taggable.php
@@ -677,6 +677,8 @@ class Taggable_mcp
 	
 	/**
 	 * Get an assoc array of IDs and names
+	 * 
+	 * @since version 1.4.8 Replaced deprecated call to set_variable for page title
 	 */
 	protected function _get_ids_and_names($data)
 	{
@@ -704,7 +706,8 @@ class Taggable_mcp
 	{
 		$this->data['title'] = lang($title);
 		
-		$this->ee->cp->set_variable('cp_page_title', lang($title)); 
+		$this->ee->view->cp_page_title = lang($title); 
+		
 		$this->ee->cp->set_breadcrumb(TAGGABLE_URL, "Taggable");
 	}
 	

--- a/third_party/taggable/views/cp/index.php
+++ b/third_party/taggable/views/cp/index.php
@@ -1,8 +1,5 @@
 <img src="<?=TAGGABLE_THEME_URL.'images/taggable-small.png'?>" alt="Taggable" style="float:left;margin:5px;margin-right:15px" />
 <p style="padding:10px"><?=lang('taggable_welcome_message')?></p>
-<p><?=lang('taggable_your_license_key_is')?> <strong>
-<?php if($license_key): ?><?=$license_key?><?php else: ?><?=lang('taggable_not_applicable')?><?php endif; ?>
-</strong></p>
 <br />
 </div></div>
 

--- a/third_party/taggable/views/cp/preferences.php
+++ b/third_party/taggable/views/cp/preferences.php
@@ -8,11 +8,6 @@
 	<tbody>
 		<?=form_open(TAGGABLE_PATH.AMP."method=preferences")?>
 				<tr>
-					<td><strong><?=lang("taggable_preference_license_key")?></strong></td>
-					<td><?=form_input('taggable_license_key', $license_key)?></td>
-				</tr>
-				
-				<tr>
 					<td><strong><?=lang("taggable_preference_default_theme")?></strong></td>
 					<td><?=form_dropdown('taggable_default_theme', $themes, $default_theme)?></td>
 				</tr>


### PR DESCRIPTION
Jamie,
I've fixed the deprecated calls as per our recent emails.
This pull will also bring in the old fix of the license key references that I fixed last year.
Hope the exams are going well.
Cheers,
Alex
